### PR TITLE
Small fix to avoid integer division issues.

### DIFF
--- a/rf95.py
+++ b/rf95.py
@@ -23,8 +23,8 @@ import sys
 import spidev
 import RPi.GPIO as GPIO
 
-FXOSC=32000000
-FSTEP = FXOSC / 524288
+FXOSC=32000000.0
+FSTEP = FXOSC / 524288.0
 
 # Register names (LoRa Mode, from table 85)
 REG_00_FIFO=0x00


### PR DESCRIPTION
This was causing incorrect frequency settings and non-operation with a RasPi Dragino Lora Hat.